### PR TITLE
Uses std::vector instead of std::list

### DIFF
--- a/RichText.hpp
+++ b/RichText.hpp
@@ -8,7 +8,7 @@
 #include <SFML/Graphics/Color.hpp>
 #include <SFML/Graphics/Text.hpp>
 #include <SFML/System/String.hpp>
-#include <list>
+#include <vector>
 
 namespace sfe
 {
@@ -19,7 +19,7 @@ public:
   //////////////////////////////////////////////////////////////////////////
   // Typedef for collection type
   //////////////////////////////////////////////////////////////////////////
-  typedef std::list<sf::Text> collection_type;
+  typedef std::vector<sf::Text> collection_type;
 
   //////////////////////////////////////////////////////////////////////////
   // Constructor


### PR DESCRIPTION
This PR is also related to #2.

Instead of using `std::list` to store the `sf::Text`s objects, I suggest to use `std::vector` for the reasons exposed [here](http://en.sfml-dev.org/forums/index.php?topic=2989.msg58148#msg58148).
