### PR TITLE
Add Outline struct for easier usage of outlines

### DIFF
--- a/RichText.cpp
+++ b/RichText.cpp
@@ -223,8 +223,15 @@ RichText::RichText(const sf::Font& font)
 ////////////////////////////////////////////////////////////////////////////////
 RichText& RichText::operator << (const TextStroke& stroke)
 {
-	m_currentStroke = stroke;
-	return *this;
+    m_currentStroke = stroke;
+    return *this;
+}
+
+RichText& RichText::operator << (const Outline& outline)
+{
+    m_currentStroke.outline = outline.outline;
+    m_currentStroke.thickness = outline.thickness;
+    return *this;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/RichText.hpp
+++ b/RichText.hpp
@@ -24,9 +24,15 @@ namespace sfe
 {
 struct TextStroke
 {
-	sf::Color fill = sf::Color::White;
-	sf::Color outline = sf::Color::Transparent;
-	float thickness = 0.f;
+    sf::Color fill = sf::Color::White;
+    sf::Color outline = sf::Color::Transparent;
+    float thickness = 0.f;
+};
+
+struct Outline
+{
+    sf::Color outline = sf::Color::Transparent;
+    float thickness = 0.f;
 };
 
 class RichText : public sf::Drawable, public sf::Transformable
@@ -126,7 +132,7 @@ public:
         // Get the index of the sf::Text containing the pos'th character.
         // Also changes pos to the position of the character in the sf::Text.
         //////////////////////////////////////////////////////////////////////
-        std::size_t convertLinePosToLocal(std::size_t& pos) const;
+        std::size_t convertLinePosToLocal(std::size_t &pos) const;
 
         //////////////////////////////////////////////////////////////////////
         // Split a string to isolate the given character
@@ -164,7 +170,8 @@ public:
     //////////////////////////////////////////////////////////////////////////
     // Operators
     //////////////////////////////////////////////////////////////////////////
-	RichText & operator << (const TextStroke &stroke);
+    RichText & operator << (const TextStroke &stroke);
+    RichText & operator << (const Outline &outline);
     RichText & operator << (const sf::Color &color);
     RichText & operator << (sf::Text::Style style);
     RichText & operator << (const sf::String &string);

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -14,7 +14,8 @@ int main()
          << sf::Text::Italic     << sf::Color::White << "is\nan\n"
          << sf::Text::Regular    << sf::Color::Green << "example"
          << sf::Color::White     << ".\n"
-         << sf::Text::Underlined << "It looks good!";
+         << sf::Text::Underlined << "It looks good!\n" << sf::Text::StrikeThrough
+         << sfe::Outline{ sf::Color::Blue, 3.f } << "Really good!";
  
     text.setCharacterSize(25);
     text.setPosition(400, 300);


### PR DESCRIPTION
- Using the new outline feature requires you to create a TextStroke object
- If you don't want to change the current fill color that was not possible
- The outline structs allows for changing the outline color and thickness